### PR TITLE
Fix a descriptive error in the document

### DIFF
--- a/doc/paddle/api/paddle/nn/layer/loss/CrossEntropyLoss_cn.rst
+++ b/doc/paddle/api/paddle/nn/layer/loss/CrossEntropyLoss_cn.rst
@@ -29,7 +29,7 @@ CrossEntropyLoss
 
 形状
 :::::::::
-    - **input** (Tensor): - 输入 `Tensor` ，数据类型为float32或float64。其形状为 :math:`[N, C]` , 其中 `C` 为类别数。对于多维度的情形下，它的形状为 :math:`[N, C, d_1, d_2, ..., d_k]` ，k >= 1。
+    - **input** (Tensor): - 输入 `Tensor` ，数据类型为float32或float64。其形状为 :math:`[N, C]` , 其中 `C` 为类别数。对于多维度的情形下，它的形状为 :math:`[N, d_1, d_2, ..., d_k, C]` ，k >= 1。
     - **label** (Tensor): - 输入input对应的标签值，数据类型为int64。其形状为 :math:`[N]` ，每个元素符合条件：0 <= label[i] <= C-1。对于多维度的情形下，它的形状为 :math:`[N, d_1, d_2, ..., d_k]` ，k >= 1。
     - **output** (Tensor): - 计算 `CrossEntropyLoss` 交叉熵后的损失值。
 


### PR DESCRIPTION
 Fix a descriptive error in the `CrossEntropyLoss` document. 